### PR TITLE
More Examples...

### DIFF
--- a/examples/entities/hierarchy.zig
+++ b/examples/entities/hierarchy.zig
@@ -5,7 +5,6 @@ const Position = struct { x: f32, y: f32 };
 const Star = struct {};
 const Planet = struct {};
 const Moon = struct {};
-const ChildOf = struct{};
 
 // TODO: Handle this with Term instead of this.
 const Iterator = struct {
@@ -38,7 +37,7 @@ fn iterateTree(world: flecs.World, e: flecs.Entity, p_parent: Position) void {
         // Iterate children recursively
 
         // TODO: Here is where we want to set the term id to the pair id
-        var it: Iterator = .{ .iter = flecs.c.ecs_term_iter(world.world, &std.mem.zeroInit(flecs.c.ecs_term_t, .{ .id = flecs.c.ECS_PAIR | (flecs.meta.componentId(world.world, ChildOf) << @as(c_int, 32)) + @intCast(u32, e.id) })) };
+        var it: Iterator = .{ .iter = flecs.c.ecs_term_iter(world.world, &std.mem.zeroInit(flecs.c.ecs_term_t, .{ .id = flecs.c.ECS_PAIR | (flecs.c.EcsChildOf << @as(c_int, 32)) + @intCast(u32, e.id) })) };
 
         while (it.next()) {
             iterateTree(world, .{ .world = world.world, .id = it.iter.entities[it.index - 1] }, p_actual);
@@ -55,32 +54,34 @@ pub fn main() !void {
     // Hierarchies use ECS relations and the builtin flecs::ChildOf relation to
     // create entities as children of other entities.
 
+    const child_of = flecs.Entity.init(world.world, flecs.c.EcsChildOf);
+
     const sun = world.newEntityWithName("Sun");
     sun.add(Star);
     sun.set(&Position{ .x = 1, .y = 1 });
 
     const mercury = world.newEntityWithName("Mercury");
-    mercury.addPair(ChildOf, sun);
+    mercury.addPair(child_of, sun);
     mercury.add(Planet);
     mercury.set(&Position{ .x = 1, .y = 1 });
 
     const venus = world.newEntityWithName("Venus");
-    venus.addPair(ChildOf, sun);
+    venus.addPair(child_of, sun);
     venus.add(Planet);
     venus.set(&Position{ .x = 2, .y = 2 });
 
     const earth = world.newEntityWithName("Earth");
-    earth.addPair(ChildOf, sun);
+    earth.addPair(child_of, sun);
     earth.add(Planet);
     earth.set(&Position{ .x = 3, .y = 3 });
 
     const moon = world.newEntityWithName("Moon");
-    moon.addPair(ChildOf, earth);
+    moon.addPair(child_of, earth);
     moon.add(Moon);
     moon.set(&Position{ .x = 0.1, .y = 0.1 });
 
     // Is the Moon a child of Earth?
-    if (moon.hasPair(ChildOf, earth))
+    if (moon.hasPair(child_of, earth))
         std.log.debug("Moon is a child of Earth!", .{});
 
     // Do a depth-first walk of the tree

--- a/examples/queries/change_tracking.zig
+++ b/examples/queries/change_tracking.zig
@@ -77,7 +77,7 @@ pub fn main() !void {
 
     // Iterate the write query. Because the Position term is InOut (default)
     // iterating the query will write to the dirty state of iterated tables.
-    var q_write_it = q_write.iterator(QWriteCallback);
+    var q_write_it = q_write.tableIterator(QWriteCallback);
     while (q_write_it.next()) |components| {
 
         std.log.debug("iterate table [{s}]", .{ q_read_it.entity().getType().?.fmt() });
@@ -100,7 +100,7 @@ pub fn main() !void {
     std.log.debug("q_read changed: {d}", .{q_read.changed()});
 
     // When we iterate the read query, we'll see that one table has changed.
-    q_read_it = q_read.iterator(QReadCallback);
+    q_read_it = q_read.tableIterator(QReadCallback);
     while (q_read_it.next()) |_| {
         std.log.debug("it.changed for table [{s}]: {d}", .{ q_read_it.entity().getType().?.fmt(), flecs.c.ecs_query_changed(q_read.query, q_read_it.iter) });
     }

--- a/examples/queries/hierarchies.zig
+++ b/examples/queries/hierarchies.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const flecs = @import("flecs");
+
+const Position = struct { x: f32, y: f32 };
+const Star = struct {};
+const Planet = struct {};
+const Moon = struct {};
+const Local = struct {};
+const World = struct {};
+
+pub fn main() !void {
+    var world = flecs.World.init();
+
+    world.registerComponents(.{ Position, Star, Planet, Moon });
+
+    // Create a simple hierarchy.
+    // Hierarchies use ECS relations and the builtin flecs::ChildOf relation to
+    // create entities as children of other entities.
+
+    const child_of = flecs.Entity.init(world.world, flecs.c.EcsChildOf);
+
+    const sun = world.newEntityWithName("Sun");
+    sun.add(Star);
+    sun.set(&Position{ .x = 1, .y = 1 });
+
+    const mercury = world.newEntityWithName("Mercury");
+    mercury.addPair(child_of, sun);
+    mercury.add(Planet);
+    mercury.set(&Position{ .x = 1, .y = 1 });
+
+    const venus = world.newEntityWithName("Venus");
+    venus.addPair(child_of, sun);
+    venus.add(Planet);
+    venus.set(&Position{ .x = 2, .y = 2 });
+
+    const earth = world.newEntityWithName("Earth");
+    earth.addPair(child_of, sun);
+    earth.add(Planet);
+    earth.set(&Position{ .x = 3, .y = 3 });
+
+    const moon = world.newEntityWithName("Moon");
+    moon.addPair(child_of, earth);
+    moon.add(Moon);
+    moon.set(&Position{ .x = 0.1, .y = 0.1 });
+
+    // Create a hierarchical query to compute the global position from the
+    // local position and the parent position.
+
+    //TODO: build this into Entity or World?
+    const position_local_id = flecs.c.ECS_PAIR | @intCast(u64, flecs.meta.componentId(world.world, Position) << 32) + flecs.meta.componentId(world.world, Local);
+    const position_world_id = flecs.c.ECS_PAIR | @intCast(u64, flecs.meta.componentId(world.world, Position) << 32) + flecs.meta.componentId(world.world, World);
+
+    var query_t = std.mem.zeroes(flecs.c.ecs_query_desc_t);
+    // Read from entity's Local position
+    query_t.filter.terms[0] = std.mem.zeroInit(flecs.c.ecs_term_t, .{ .id = position_local_id, .inout = flecs.c.EcsIn });
+    // Write to entity's World position
+    query_t.filter.terms[1] = std.mem.zeroInit(flecs.c.ecs_term_t, .{ .id = position_world_id, .inout = flecs.c.EcsOut });
+    // Read from parent's World position
+    query_t.filter.terms[2] = std.mem.zeroes(flecs.c.ecs_term_t);
+    query_t.filter.terms[2].id = position_world_id;
+    query_t.filter.terms[2].inout = flecs.c.EcsIn;
+    query_t.filter.terms[2].oper = flecs.c.EcsOptional;
+    query_t.filter.terms[2].subj.set.mask = flecs.c.EcsParent | flecs.c.EcsCascade;
+
+    const QCallback = struct { local: *const Position, world: *Position, parent: ?*const Position };
+
+    var q = flecs.Query.init(world, &query_t);
+    var it = q.tableIterator(QCallback);
+
+    // Do the transform
+    while (it.next()) |tables| {
+        // Inner loop, iterates entities in archetype
+        var i: usize = 0;
+        while (i < tables.count) : (i += 1) {
+            tables.data.world[i].x = tables.data.local[i].x;
+            tables.data.world[i].y = tables.data.local[i].y;
+
+            if (tables.data.parent) |parent| {
+                tables.data.world[i].x += parent[i].x;
+                tables.data.world[i].y += parent[i].y;
+            }
+        }
+    }
+
+    // Print ecs positions
+    
+}


### PR DESCRIPTION
Okay, this time I just cleaned up a couple things in previous examples and tried to work on the [hierarchies example](https://github.com/SanderMertens/flecs/blob/master/examples/c/queries/hierarchies/src/main.c).

I think we are going to have to think about this, because before I tried to shove `Pair` into either `World` or `Entity`, I tried to just implement it in the file itself and found out that we might have a roadblock. If you try to run this example, you get an error that the `struct doesn't match the order of iter.terms`, which is correct because the id passed in to the `ecs_query_desc_t` is that of a pair, not the id of a type, which is I believe what the current implementation is expecting.

The second issue here is that we are expecting three different `Position`s to be returned, which blocks us from using the `modifiers`, because we can't know which `Position` to apply the modifier to...

I'll have to think on this, but I wanted to go ahead and PR it in-case you wanted to think on it too.