### PR TITLE
More Examples...

### DIFF
--- a/examples/systems/delta_time.zig
+++ b/examples/systems/delta_time.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const flecs = @import("flecs");
+
+const EmptyCallback = struct {
+    pub const name = "PrintDeltaTime";
+    pub const run = printDeltaTime;
+};
+
+fn printDeltaTime(iter: *flecs.Iterator(EmptyCallback)) void {
+    std.log.debug("delta_time: {d}", .{ iter.iter.delta_time });
+}
+
+pub fn main() !void {
+    var world = flecs.World.init();
+
+    // Create system that prints delta_time. This system doesn't query for any
+    // components which means it won't match any entities, but will still be ran
+    // once for each call to ecs_progress.
+    world.system(EmptyCallback, .on_update);
+
+    // Call progress with 0.0f for the delta_time parameter. This will cause
+    // ecs_progress to measure the time passed since the last frame. The
+    // delta_time of the first frame is a best guess (16ms).
+    world.progress(0);
+
+    // The following calls should print a delta_time of approximately 100ms
+    std.os.nanosleep(0, 100 * 100 * 1000);
+    world.progress(0);
+
+    std.os.nanosleep(0, 100 * 100 * 1000);
+    world.progress(0);
+
+    world.deinit();
+}

--- a/examples/systems/mutate_entity.zig
+++ b/examples/systems/mutate_entity.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const flecs = @import("flecs");
+const q = flecs.queries;
+
+const Timeout = struct {
+    value: f32,
+};
+
+const ExpireCallback = struct {
+    timeout: *Timeout,
+    pub const name = "Expire";
+    pub const run = expire;
+};
+
+// System that deletes an entity after a timeout expires
+fn expire(it: *flecs.Iterator(ExpireCallback)) void {
+    while (it.next()) |components| {
+        components.timeout.value -= it.iter.delta_time;
+        if (components.timeout.value <= 0) {
+            // When deleting the entity, use the world provided by the iterator.
+
+            // To make sure that the storage doesn't change while a system is
+            // iterating entities, and multiple threads can safely access the
+            // data, mutations (like a delete) are added to a command queue and
+            // executed when it's safe to do so.
+
+            // A system should not use the world pointer that is provided by the
+            // ecs_init function, as this will throw an error that the world is
+            // in readonly mode (try replacing it->world with it->real_world).
+            std.log.debug("Expire: {s} deleted!", .{it.entity().getName()});
+            it.entity().delete();
+        }
+    }
+}
+
+const PrintExpireCallback = struct {
+    timeout: *const Timeout,
+
+    pub const name = "PrintExpire";
+    pub const run = printExpire;
+};
+
+// System that prints remaining expiry time
+fn printExpire(it: *flecs.Iterator(PrintExpireCallback)) void {
+    while (it.next()) |components| {
+        std.log.debug("PrintExpire: {s} has {d} seconds left", .{ it.entity().getName(), components.timeout.value });
+    }
+}
+
+const ObserverCallback = struct {
+    timeout: *const Timeout,
+
+    pub const name = "Expired";
+    pub const run = expired;
+};
+
+// Observer that triggers when the component is actually removed
+fn expired(it: *flecs.Iterator(ObserverCallback)) void {
+    std.log.debug("Expired: {s} actually deleted", .{it.entity().getName()});
+}
+
+pub fn main() !void {
+    var world = flecs.World.init();
+
+    world.system(ExpireCallback, .on_update);
+    world.system(PrintExpireCallback, .on_update);
+    world.observer(ObserverCallback, .on_remove);
+
+    const e = world.newEntityWithName("MyEntity");
+    e.set(&Timeout{ .value = 3 });
+
+    world.setTargetFps(1);
+
+    var progress: bool = true;
+    while (progress) {
+        world.progress(0);
+
+        if (!e.isAlive()) {
+            break;
+        }
+     
+    }
+}

--- a/examples/systems/mutate_entity.zig
+++ b/examples/systems/mutate_entity.zig
@@ -56,7 +56,8 @@ const ObserverCallback = struct {
 
 // Observer that triggers when the component is actually removed
 fn expired(it: *flecs.Iterator(ObserverCallback)) void {
-    std.log.debug("Expired: {s} actually deleted", .{it.entity().getName()});
+    _ = it;
+    std.log.debug("Expired: {s} actually deleted", .{ "Entity.getName"});
 }
 
 pub fn main() !void {

--- a/examples/systems/mutate_entity.zig
+++ b/examples/systems/mutate_entity.zig
@@ -56,6 +56,8 @@ const ObserverCallback = struct {
 
 // Observer that triggers when the component is actually removed
 fn expired(it: *flecs.Iterator(ObserverCallback)) void {
+    // TODO: the entity of this iterator is empty I think
+    // std.log.debug("Expired: {s} actually deleted", .{ it.entity().getName() });
     _ = it;
     std.log.debug("Expired: {s} actually deleted", .{ "Entity.getName"});
 }

--- a/examples/systems/system_basics.zig
+++ b/examples/systems/system_basics.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const flecs = @import("flecs");
+
+const Position = struct { x: f32, y: f32 };
+const Velocity = struct { x: f32, y: f32 };
+
+const MoveCallback = struct {
+    position: *Position,
+    velocity: *const Velocity,
+
+    pub const name = "Move";
+    pub const run = move;
+};
+
+fn move(iter: *flecs.Iterator(MoveCallback)) void {
+    while (iter.next()) |components| {
+        components.position.x += components.velocity.x;
+        components.position.y += components.velocity.y;
+        std.log.debug("{s}: {d}", .{ iter.entity().getName(), components.position });
+    }
+}
+
+pub fn main() !void {
+    var world = flecs.World.init();
+
+    // Create a system for Position, Velocity. Systems are like queries (see
+    // queries) with a function that can be ran or scheduled (see pipeline).
+    world.system(MoveCallback, .on_update);
+
+    // Create a few test entities for a Position, Velocity query
+    const e1 = world.newEntityWithName("e1");
+    e1.set(&Position{ .x = 10, .y = 20});
+    e1.set(&Velocity{ .x = 1, .y = 2});
+
+    const e2 = world.newEntityWithName("e2");
+    e2.set(&Position{ .x = 10, .y = 20});
+    e2.set(&Velocity{ .x = 3, .y = 4});
+
+    // This entity will not match as it does not have Position, Velocity
+    const e3 = world.newEntityWithName("e3");
+    e3.set(&Position{ .x = 10, .y = 20});
+
+    world.progress(1);
+
+    world.deinit();
+}

--- a/src/entity.zig
+++ b/src/entity.zig
@@ -109,7 +109,11 @@ pub const Entity = struct {
     /// removes the entity from the world. Do not use this Entity after calling this!
     pub fn delete(self: Entity) void {
         flecs.c.ecs_delete(self.world, self.id);
-        self.id = 0;
+    }
+
+    /// returns true if the entity is alive
+    pub fn isAlive(self: Entity) bool {
+        return flecs.c.ecs_is_alive(self.world, self.id);
     }
 
     /// returns true if the entity has a matching component type

--- a/src/flecs.zig
+++ b/src/flecs.zig
@@ -39,6 +39,21 @@ pub const Phase = enum(c.ecs_id_t) {
     post_frame = c.ECS_HI_COMPONENT_ID + 74,
 };
 
+pub const Event = enum(c.ecs_id_t) {
+    // Event. Triggers when an id (component, tag, pair) is added to an entity
+    on_add = c.ECS_HI_COMPONENT_ID + 30,
+    // Event. Triggers when an id (component, tag, pair) is removed from an entity
+    on_remove = c.ECS_HI_COMPONENT_ID + 31,
+    // Event. Triggers when a component is set for an entity
+    on_set = c.ECS_HI_COMPONENT_ID + 32,
+    // Event. Triggers when a component is unset for an entity 
+    un_set = c.ECS_HI_COMPONENT_ID + 33,
+    // Event. Triggers when an entity is deleted.
+    on_delete = c.ECS_HI_COMPONENT_ID + 34,
+    // Event. Exactly-once trigger for when an entity matches/unmatches a filter
+    monitor = c.ECS_HI_COMPONENT_ID + 61,
+};
+
 pub const OperKind = enum(c_int) {
     and_ = c.EcsAnd,
     or_ = c.EcsOr,


### PR DESCRIPTION
Alright this time we have some more systems examples, and I went ahead and added the `observer` system setup to the `World`, with the matching events. 

One issue popped up, and that's the debug print of the entity name when it was actually deleted. It seems to make sense that the entity is gone by the time this event is called, but the Flecs example has it this way. I assume we need to make sure the iterator's `entity` function still works the frame the entity is deleted. I'll look into it.