### PR TITLE
Allow order_by to include types only in Filter

### DIFF
--- a/src/meta.zig
+++ b/src/meta.zig
@@ -234,6 +234,18 @@ pub fn validateOrderByType(comptime Components: type, comptime T: type) void {
                 valid = true;
             }
         }
+
+        // allow types in Filter with no fields
+        if (@hasDecl(Components, "modifiers")) {
+            inline for (Components.modifiers) |inout_tuple| {
+                const ti = TermInfo.init(inout_tuple);
+                if (ti.inout == flecs.c.EcsInOutFilter) {
+                    if (ti.term_type == T)
+                        valid = true;
+                }
+            }
+        }
+
         assertMsg(valid, "type {any} was not found in the struct!", .{T});
     }
 }


### PR DESCRIPTION
Just a small change to allow you to order by a type that you aren't interested in capturing, but still need to match, such as a Filter.