### PR TITLE
add setModified method to Entity

### DIFF
--- a/src/entity.zig
+++ b/src/entity.zig
@@ -94,6 +94,11 @@ pub const Entity = struct {
         _ = flecs.c.ecs_set_id(self.world, self.id, id, @sizeOf(T), component);
     }
 
+    /// sets a component as modified, and will trigger observers after being modified from a system
+    pub fn setModified(self: Entity, comptime T: type) void {
+        flecs.c.ecs_modified_id(self.world, self.id, meta.componentId(self.world, T));
+    }
+
     /// gets a pointer to a type if the component is present on the entity
     pub fn get(self: Entity, comptime T: type) ?*const T {
         const ptr = flecs.c.ecs_get_id(self.world, self.id, meta.componentId(self.world, T));


### PR DESCRIPTION
Just adds a `setModified` method to Entity. I didn't realize that `set` is the only way to trigger an observer's event, and that if you write to a component from a system, the observer won't see those changes, even if it's set to `Out`. After talking to Sander, the only other way to trigger an observer outside of `set` is to call `ecs_modified` after changing the component data via system.