### PR TITLE
Way to iterate children of a parent entity?

### DIFF
--- a/examples/entities/entities_hierarchy.zig
+++ b/examples/entities/entities_hierarchy.zig
@@ -57,9 +57,22 @@ pub fn main() !void {
     moon.set(&Position{ .x = 0.1, .y = 0.1 });
 
     // Is the Moon a child of Earth?
-    if (moon.hasPair(flecs.c.EcsChildOf, earth))
+    if (moon.hasPair(flecs.c.EcsChildOf, earth)) 
         std.log.debug("Moon is a child of Earth!", .{});
 
     // Do a depth-first walk of the tree
     iterateTree(world, sun, .{ .x = 0, .y = 0 });
+
+    const FilterCallback = struct {
+        position: *const Position,
+    };
+
+    std.log.debug("Iterate children of earth:", .{});
+
+    var filter = world.filterParent(FilterCallback, earth);
+    var iter = filter.iterator(FilterCallback);
+
+    while (iter.next()) |comps| {
+        std.log.debug("{s} : {any}", .{ iter.entity().getName(), comps.position});
+    }
 }


### PR DESCRIPTION
Okay, so feel free to close this without merging if you have a better idea, but I've been trying to figure out a way to iterate the children of an entity and build it into what we have currently, but I couldn't find a clean way to do it. 

The "struct" way of handling queries and filters and all that can't be used, because we can't pass a runtime value into the type of the struct (the parent entity id, used with the `flecs.c.EcsChildOf` value to get a pair). 

Having a different method for the host of potential pairs you could want isn't ideal either. 

I also tried just directly setting the term's id in the underlying `ecs_filter_desc_t` after calling `world.filter(T)` but that didn't work either. 

Check out the `entities_hierarchy` example if you wanna give it a shot. I think being able to easily iterate children of a parent is a pretty important feature to support. 