### PR TITLE
Fix filters `entity` method.

### DIFF
--- a/src/filter.zig
+++ b/src/filter.zig
@@ -27,7 +27,7 @@ pub const Filter = struct {
         }
 
         pub fn entity(self: *@This()) flecs.Entity {
-            return flecs.Entity.init(flecs.World{ .world = self.iter.world }, self.iter.entities[self.index - 1]);
+            return flecs.Entity.init(self.iter.world.?, self.iter.entities[self.index - 1]);
         }
 
         /// gets the index into the terms array of this type


### PR DESCRIPTION
It was trying to create a `World` struct when what we needed was to just pass the raw c type.